### PR TITLE
samples/sgemm >> Correcting a variable for error checking..

### DIFF
--- a/samples/sgemm/sgemm.cpp
+++ b/samples/sgemm/sgemm.cpp
@@ -161,7 +161,7 @@ int main(void)
     setKernelArgumentsSuccess &= checkSuccess(clSetKernelArg(kernel, 3, sizeof(cl_uint), &matrixOrder));
     setKernelArgumentsSuccess &= checkSuccess(clSetKernelArg(kernel, 4, sizeof(cl_float), &alpha));
     setKernelArgumentsSuccess &= checkSuccess(clSetKernelArg(kernel, 5, sizeof(cl_float), &beta));
-    if (!createMemoryObjectsSuccess)
+    if (!setKernelArgumentsSuccess)
     {
         cleanUpOpenCL(context, commandQueue, program, kernel, memoryObjects, numberOfMemoryObjects);
         cerr << "Failed setting OpenCL kernel arguments. " << __FILE__ << ":"<< __LINE__ << endl;


### PR DESCRIPTION
Minor correction on sample code :
While I was looking the source code at samples/sgemm I noticed that the '_setKernelArgumentsSuccess_' variable was not in use. Checking other examples I think that it may be a mistake. Notice that the error-checking, at next line, is referred to '_createMemoryObjectsSuccess_'.